### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This will open a window containing the application.
 From there you can select the quantity and size die you want to roll along with the modifier to be added to the die.
 Click 'Roll' and your results will display
 Click 'Cancel' and the application will close
+
+[![Run on Repl.it](https://repl.it/badge/github/AndrewPRohde/DiceRoller)](https://repl.it/github/AndrewPRohde/DiceRoller)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).